### PR TITLE
Add repo link in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
   },
   "author": "Harness Inc",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/harness/ff-react-native-client-sdk.git"
+},
   "dependencies": {
     "react": "16.13.1",
     "react-native": "0.63.2"


### PR DESCRIPTION
This makes it easier to find the npm package's repo on npmjs.com.
Also, it is used by security tooling to help verify the integrity of npm packages.